### PR TITLE
Fix startup and load crashes in IBL mode

### DIFF
--- a/ibl_alignment_gui/handlers/probe_handler.py
+++ b/ibl_alignment_gui/handlers/probe_handler.py
@@ -444,7 +444,7 @@ class ProbeHandlerONE(ProbeHandler):
             An array of subject names
         """
         self.sess_ins = self.one.alyx.rest(
-            'insertions', 'list', dataset_type='spikes.times', expires=timedelta(days=1)
+            'insertions', 'list', dataset_types='spikes.times', expires=timedelta(days=1)
         )
         self.subj_ins = [sess['session_info']['subject'] for sess in self.sess_ins]
         self.subjects = np.unique(self.subj_ins)

--- a/ibl_alignment_gui/loaders/data_loader.py
+++ b/ibl_alignment_gui/loaders/data_loader.py
@@ -17,7 +17,7 @@ from brainbox.io.spikeglx import Streamer
 from ibl_alignment_gui.utils.parse_yaml import DatasetPaths
 from iblutil.numerical import ismember
 from iblutil.util import Bunch
-from one.alf.exceptions import ALFObjectNotFound
+from one.alf.exceptions import ALFMultipleCollectionsFound, ALFObjectNotFound
 from one.api import ONE
 from one.remote import aws
 
@@ -78,7 +78,10 @@ class DataLoader(ABC):
         load_function: Callable,
         *args: Any,
         raise_message: str | None = None,
-        raise_exception: Exception = ALFObjectNotFound,
+        raise_exception: type[Exception] | tuple[type[Exception], ...] = (
+            ALFObjectNotFound,
+            ALFMultipleCollectionsFound,
+        ),
         raise_error: bool = False,
         **kwargs,
     ) -> Bunch[str, Any]:
@@ -110,9 +113,16 @@ class DataLoader(ABC):
                 data['exists'] = True
             return data
         except raise_exception as e:
-            raise_message = raise_message or (
-                f'{alf_object} data was not found, some plots will not display'
-            )
+            if raise_message is None:
+                if isinstance(e, ALFMultipleCollectionsFound):
+                    raise_message = (
+                        f'{alf_object} data matches multiple collections ({e}); '
+                        f'cannot disambiguate, some plots will not display'
+                    )
+                else:
+                    raise_message = (
+                        f'{alf_object} data was not found, some plots will not display'
+                    )
             logger.warning(raise_message)
             if raise_error:
                 logger.error(raise_message)


### PR DESCRIPTION
## Summary
- `ProbeHandlerONE.get_subjects` used the old singular `dataset_type` query param, which ONE-api >=3.4 rejects because the current Alyx OpenAPI schema exposes it as `dataset_types` (plural). The GUI crashed at startup in IBL mode. Renamed to match the schema.
- `DataLoaderOne.load_passive_data` calls `one.load_object(eid, object)` with no `collection=` argument. Sessions with multiple task collections (e.g. LSD sessions with `alf/task_00` + `alf/task_01`) raised `ALFMultipleCollectionsFound`, which `DataLoader.load_data` did not catch, aborting session loading. Widen the default caught exceptions to include `ALFMultipleCollectionsFound` and emit a distinct warning. Downstream plot code already gates on the `exists` flag, so affected plots are skipped gracefully.

## Test plan
- [x] `alignment-gui-ibl` launches and populates the subject dropdown
- [x] Loading a session with multiple task collections completes without exception and logs a clear "matches multiple collections" warning instead of "data was not found"
- [x] Existing test suite passes (76 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)