### PR TITLE
Load stored alignment by default

### DIFF
--- a/ibl_alignment_gui/app/app_controller.py
+++ b/ibl_alignment_gui/app/app_controller.py
@@ -844,8 +844,8 @@ class AlignmentGUIController:
         self.view.clear_selection_dropdown('align')
         self.model.set_info(idx)
         self.view.populate_selection_dropdown('align', self.model.get_previous_alignments())
-        # Load the initial alignment
-        self.model.get_starting_alignment(0)
+        # Load the stored (resolved) alignment if available, otherwise the most recent
+        self.model.get_starting_alignment(self.model.get_stored_alignment_idx())
         if self.loaded is not None:
             # If in tab view, update the tab to display the selected shank
             self.view.set_tabs(idx)

--- a/ibl_alignment_gui/handlers/probe_handler.py
+++ b/ibl_alignment_gui/handlers/probe_handler.py
@@ -166,6 +166,23 @@ class ProbeHandler(ABC):
         for config in self.configs:
             self.get_selected_shank()[config].loaders['align'].get_starting_alignment(idx)
 
+    def get_stored_alignment_idx(self) -> int:
+        """
+        Return the index of the stored (resolved) alignment for the selected shank.
+
+        Delegates to the default configuration's alignment loader.
+
+        Returns
+        -------
+        int
+            Index of the stored alignment in the alignment keys list, or 0 if not found.
+        """
+        return (
+            self.get_selected_shank()[self.default_config]
+            .loaders['align']
+            .get_stored_alignment_idx()
+        )
+
     def set_init_alignment(self) -> None:
         """Initialise the alignment for the selected shank and each configuration."""
         for config in self.configs:
@@ -770,19 +787,20 @@ class ProbeHandlerCSV(ProbeHandler):
             if dense_align.alignment_keys != ['original']:
                 # Alyx alignment exists: overwrite local
                 quarter_align.alignments = dense_align.alignments
+                quarter_align.stored_alignment_key = dense_align.stored_alignment_key
                 quarter_align.get_previous_alignments()
-                quarter_align.get_starting_alignment(0)
+                quarter_align.get_starting_alignment(quarter_align.get_stored_alignment_idx())
 
             elif quarter_align.alignment_keys != ['original']:
                 # Local alignment exists: add to online
                 dense_align.add_extra_alignments(quarter_align.alignments)
                 dense_align.get_previous_alignments()
-                dense_align.get_starting_alignment(0)
+                dense_align.get_starting_alignment(dense_align.get_stored_alignment_idx())
 
                 # Ensure consistency by syncing quarter with updated dense
                 quarter_align.alignments = dense_align.alignments
                 quarter_align.get_previous_alignments()
-                quarter_align.get_starting_alignment(0)
+                quarter_align.get_starting_alignment(quarter_align.get_stored_alignment_idx())
 
     def get_insertion(self, shank: pd.Series) -> dict:
         """Get the alyx probe insertion for the shank."""

--- a/ibl_alignment_gui/handlers/shank_handler.py
+++ b/ibl_alignment_gui/handlers/shank_handler.py
@@ -27,7 +27,7 @@ class ShankHandler:
         self.shank_idx: int = shank_idx
         self.loaders: Bunch = loaders
         self.loaders['align'].load_previous_alignments()
-        self.loaders['align'].get_starting_alignment(0)
+        self.loaders['align'].get_starting_alignment(self.loaders['align'].get_stored_alignment_idx())
         self.align_exists: bool = True
         self.data_loaded: bool = False
         self.align_handle = None

--- a/ibl_alignment_gui/loaders/alignment_loader.py
+++ b/ibl_alignment_gui/loaders/alignment_loader.py
@@ -36,6 +36,7 @@ class AlignmentLoader(ABC):
         self.alignment_keys: list = ['original']
         self.feature_prev: np.ndarray | None = None
         self.track_prev: np.ndarray | None = None
+        self.stored_alignment_key: str | None = None
 
     @abstractmethod
     def load_alignments(self) -> dict[str, Any] | None:
@@ -92,6 +93,22 @@ class AlignmentLoader(ABC):
             self.feature_prev = np.array(self.alignments[self.alignment_keys[idx]][0])
             self.track_prev = np.array(self.alignments[self.alignment_keys[idx]][1])
 
+    def get_stored_alignment_idx(self) -> int:
+        """
+        Return the index of the stored (resolved) alignment in the alignment keys list.
+
+        If no stored alignment is set or the stored key is not present in the current
+        alignment keys, returns 0 (i.e. the most recent alignment).
+
+        Returns
+        -------
+        int
+            Index of the stored alignment in ``self.alignment_keys``, or 0 if not found.
+        """
+        if self.stored_alignment_key is None or self.stored_alignment_key not in self.alignment_keys:
+            return 0
+        return self.alignment_keys.index(self.stored_alignment_key)
+
     def add_extra_alignments(self, extra_alignments: dict[str, Any]) -> list[str]:
         """
         Add additional alignment data.
@@ -143,6 +160,10 @@ class AlignmentLoaderOne(AlignmentLoader):
         self.traj_id: str | None = None
 
         super().__init__(user=user)
+
+        self.stored_alignment_key: str | None = (
+            insertion['json'].get('extended_qc', {}).get('alignment_stored')
+        )
 
     def load_xyz_picks(self) -> np.ndarray | None:
         """

--- a/tests/loaders/test_alignment_loader.py
+++ b/tests/loaders/test_alignment_loader.py
@@ -92,6 +92,21 @@ class TestAlignmentLoaderOne(unittest.TestCase):
             np.testing.assert_array_equal(self.loader.feature_prev, np.array([-0.006, 0.006]))
             np.testing.assert_array_equal(self.loader.track_prev, np.array([-0.006, 0.006]))
 
+    def test_stored_alignment_idx(self):
+        """Test get_stored_alignment_idx returns stored key index or 0 as fallback."""
+        self.loader.alignment_keys = ['2025-07-03_user1', '2025-06-10_user2', 'original']
+        self.assertEqual(self.loader.get_stored_alignment_idx(), 0)  # no stored key
+        self.loader.stored_alignment_key = '2025-06-10_user2'
+        self.assertEqual(self.loader.get_stored_alignment_idx(), 1)  # key present
+        self.loader.stored_alignment_key = '2025-01-01_other'
+        self.assertEqual(self.loader.get_stored_alignment_idx(), 0)  # key missing
+
+    def test_stored_alignment_key_from_insertion(self):
+        """Test stored_alignment_key is read from insertion extended_qc on construction."""
+        ins = {'id': uuid.uuid4(), 'json': {'extended_qc': {'alignment_stored': '2025-06-10_user2'}}}
+        loader = AlignmentLoaderOne(ins, self.one_mock)
+        self.assertEqual(loader.stored_alignment_key, '2025-06-10_user2')
+
     def test_extra_alignment(self):
         """Test the add_extra_alignments method"""
         self.loader.alignments = self.alignments


### PR DESCRIPTION
When `alignment_resolved=True`, load the stored alignment (from `extended_qc.alignment_stored`) as the default on GUI startup instead of always loading the most recent one. Falls back to index 0 when no stored key is set.

**Changes:**
- `AlignmentLoader`: new `stored_alignment_key` attribute + `get_stored_alignment_idx()` method
- `AlignmentLoaderOne`: reads `stored_alignment_key` from `insertion['json']['extended_qc']['alignment_stored']`
- `ShankHandler`, `ProbeHandler`, `app_controller`: use `get_stored_alignment_idx()` on load
- `_sync_alignments`: propagates `stored_alignment_key` from dense to quarter loader
- Post-upload still defaults to index 0 (the freshly-saved alignment)